### PR TITLE
Add basic processing pipeline webapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+logs/
+output/
+input/
+work/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # DataSetKurator
+
+A minimal pipeline to convert an uploaded video into a basic dataset. Steps are logged to `logs/process.log`.
+
+## Usage
+
+1. Install dependencies
+   ```bash
+   pip install flask
+   ```
+2. Run the web app
+   ```bash
+   python app.py
+   ```
+3. Open `http://localhost:8000` in your browser
+
+Upload a video, start the pipeline and download the resulting zip file.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,59 @@
+from flask import Flask, request, render_template_string, send_file
+from pathlib import Path
+import shutil
+
+from pipeline.pipeline_runner import Pipeline
+from pipeline.logging_utils import LOG_FILE
+
+INPUT_DIR = Path('input')
+OUTPUT_DIR = Path('output')
+WORK_DIR = Path('work')
+
+app = Flask(__name__)
+
+template = """
+<!doctype html>
+<title>DataSetKurator</title>
+<h1>Upload Video</h1>
+<form method=post enctype=multipart/form-data action="/upload">
+  <input type=file name=video>
+  <input type=submit value=Upload>
+</form>
+<form method=post action="/start">
+  <button type=submit>Start Pipeline</button>
+</form>
+"""
+
+@app.route('/')
+def index():
+    return render_template_string(template)
+
+@app.route('/upload', methods=['POST'])
+def upload():
+    file = request.files['video']
+    if not file:
+        return 'No file uploaded', 400
+    INPUT_DIR.mkdir(exist_ok=True)
+    video_path = INPUT_DIR / file.filename
+    file.save(video_path)
+    return 'Upload successful: ' + file.filename
+
+@app.route('/start', methods=['POST'])
+def start():
+    videos = list(INPUT_DIR.glob('*'))
+    if not videos:
+        return 'No videos found in input', 400
+    video = videos[0]
+    pipeline = Pipeline(INPUT_DIR, OUTPUT_DIR, WORK_DIR)
+    try:
+        zip_path = pipeline.run(video)
+    except Exception:
+        return send_file(LOG_FILE, as_attachment=True)
+    finally:
+        # clean input
+        for f in INPUT_DIR.glob('*'):
+            f.unlink()
+    return send_file(zip_path, as_attachment=True)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8000)

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['pipeline_runner', 'steps', 'logging_utils']

--- a/pipeline/logging_utils.py
+++ b/pipeline/logging_utils.py
@@ -1,0 +1,19 @@
+import logging
+from pathlib import Path
+
+LOG_FILE = Path('logs/process.log')
+
+LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE, encoding='utf-8'),
+    ]
+)
+
+logger = logging.getLogger('dataset_kurator')
+
+def log_step(step: str):
+    logger.info(step)

--- a/pipeline/pipeline_runner.py
+++ b/pipeline/pipeline_runner.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+import shutil
+import zipfile
+
+from .logging_utils import log_step
+from .steps import frame_extraction, deduplication, classification, filtering, upscaling, cropping, annotation
+
+
+class Pipeline:
+    def __init__(self, input_dir: Path, output_dir: Path, work_dir: Path):
+        self.input_dir = input_dir
+        self.output_dir = output_dir
+        self.work_dir = work_dir
+
+    def cleanup(self):
+        if self.work_dir.exists():
+            shutil.rmtree(self.work_dir)
+
+    def run(self, video_path: Path):
+        try:
+            self.output_dir.mkdir(parents=True, exist_ok=True)
+            work_frames = self.work_dir / 'frames'
+            frames = frame_extraction.run(video_path, work_frames)
+
+            work_dedup = self.work_dir / 'dedup'
+            deduped = deduplication.run(frames, work_dedup)
+            shutil.rmtree(work_frames)
+
+            work_class = self.work_dir / 'classification'
+            classified = classification.run(deduped, work_class)
+            shutil.rmtree(work_dedup)
+
+            work_filter = self.work_dir / 'filtering'
+            filtered = filtering.run(classified, work_filter)
+            shutil.rmtree(work_class)
+
+            work_upscale = self.work_dir / 'upscaling'
+            upscaled = upscaling.run(filtered, work_upscale)
+            shutil.rmtree(work_filter)
+
+            work_crop = self.work_dir / 'cropping'
+            cropped = cropping.run(upscaled, work_crop)
+            shutil.rmtree(work_upscale)
+
+            captions_dir = self.output_dir / 'captions'
+            images_dir = self.output_dir / 'images'
+            images_dir.mkdir(exist_ok=True)
+            for img in sorted(cropped.glob('*.png')):
+                shutil.copy(img, images_dir / img.name)
+            annotation.run(cropped, captions_dir)
+            shutil.rmtree(work_crop)
+
+            # Zip output
+            zip_path = self.output_dir.with_suffix('.zip')
+            with zipfile.ZipFile(zip_path, 'w') as zf:
+                for path in self.output_dir.rglob('*'):
+                    zf.write(path, path.relative_to(self.output_dir))
+            log_step(f'Pipeline completed successfully: {zip_path}')
+            return zip_path
+        except Exception as e:
+            log_step(f'Pipeline failed: {e}')
+            raise
+        finally:
+            self.cleanup()

--- a/pipeline/steps/__init__.py
+++ b/pipeline/steps/__init__.py
@@ -1,0 +1,11 @@
+from . import frame_extraction, deduplication, classification, filtering, upscaling, cropping, annotation
+
+__all__ = [
+    'frame_extraction',
+    'deduplication',
+    'classification',
+    'filtering',
+    'upscaling',
+    'cropping',
+    'annotation',
+]

--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+from ..logging_utils import log_step
+
+
+def run(cropped_dir: Path, captions_dir: Path) -> None:
+    """Placeholder annotation step that creates dummy captions."""
+    captions_dir.mkdir(parents=True, exist_ok=True)
+    log_step('Annotation started')
+    for img in sorted(cropped_dir.glob('*.png')):
+        caption_file = captions_dir / f"{img.stem}.txt"
+        caption_file.write_text('1girl, solo, anime_style')
+    log_step('Annotation completed')

--- a/pipeline/steps/classification.py
+++ b/pipeline/steps/classification.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import shutil
+from ..logging_utils import log_step
+
+
+def run(frames_dir: Path, workdir: Path) -> Path:
+    """Placeholder classification step."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    log_step('Classification started')
+    target = workdir / 'character'
+    target.mkdir(exist_ok=True)
+    for frame in sorted(frames_dir.glob('*.png')):
+        shutil.copy(frame, target / frame.name)
+    log_step('Classification completed')
+    return target

--- a/pipeline/steps/cropping.py
+++ b/pipeline/steps/cropping.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import shutil
+from ..logging_utils import log_step
+
+
+def run(upscaled_dir: Path, workdir: Path) -> Path:
+    """Placeholder cropping step."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    log_step('Cropping started')
+    for img in sorted(upscaled_dir.glob('*.png')):
+        shutil.copy(img, workdir / img.name)
+    log_step('Cropping completed')
+    return workdir

--- a/pipeline/steps/deduplication.py
+++ b/pipeline/steps/deduplication.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+import shutil
+from ..logging_utils import log_step
+
+
+def run(frames_dir: Path, workdir: Path) -> Path:
+    """Simplified deduplication that copies files."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    log_step('Deduplication started')
+    for frame in sorted(frames_dir.glob('*.png')):
+        dest = workdir / frame.name
+        shutil.copy(frame, dest)
+    log_step('Deduplication completed')
+    return workdir

--- a/pipeline/steps/filtering.py
+++ b/pipeline/steps/filtering.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import shutil
+from ..logging_utils import log_step
+
+
+def run(classified_dir: Path, workdir: Path) -> Path:
+    """Placeholder filtering step."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    log_step('Filtering started')
+    for img in sorted(classified_dir.glob('*.png')):
+        shutil.copy(img, workdir / img.name)
+    log_step('Filtering completed')
+    return workdir

--- a/pipeline/steps/frame_extraction.py
+++ b/pipeline/steps/frame_extraction.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import subprocess
+from ..logging_utils import log_step
+
+
+def run(video: Path, workdir: Path) -> Path:
+    """Extract frames from the video using ffmpeg."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    output_pattern = workdir / 'frame_%04d.png'
+    log_step('Frame Extraction started')
+    try:
+        subprocess.run([
+            'ffmpeg', '-i', str(video), '-vf', 'fps=1', str(output_pattern)
+        ], check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError as e:
+        log_step(f'Frame extraction failed: {e}')
+        raise
+    log_step('Frame Extraction completed')
+    return workdir

--- a/pipeline/steps/upscaling.py
+++ b/pipeline/steps/upscaling.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import shutil
+from ..logging_utils import log_step
+
+
+def run(filtered_dir: Path, workdir: Path) -> Path:
+    """Placeholder upscaling step."""
+    workdir.mkdir(parents=True, exist_ok=True)
+    log_step('Upscaling started')
+    for img in sorted(filtered_dir.glob('*.png')):
+        shutil.copy(img, workdir / img.name)
+    log_step('Upscaling completed')
+    return workdir


### PR DESCRIPTION
## Summary
- scaffold pipeline modules and runner
- add Flask web interface for uploading and processing videos
- provide logging utilities writing to `logs/process.log`
- document usage in README
- add `.gitignore`

## Testing
- `python -m py_compile app.py pipeline/*.py pipeline/steps/*.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d1cb0af4c83339c3943d58808f9f0