### PR TITLE
Add automatic tagging step

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,6 @@ The third stage uses an anime-focused CLIP model and DBSCAN clustering to
 automatically group frames by character.
 The cropping stage relies on the ``animeface`` library to detect faces and
 produce crops around them, keeping the entire image when no face is found.
+The annotation stage applies the *WD14* tagger to each cropped image and
+generates a comma-separated list of tags, falling back to a simple
+``anime_style`` caption if the model cannot be loaded.

--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -1,12 +1,80 @@
+"""Automatic tagging using the WD14 tagger."""
+
 from pathlib import Path
+from typing import List, Any
+import csv
+
+from PIL import Image
+import torch
+import open_clip
+from huggingface_hub import hf_hub_download
+
 from ..logging_utils import log_step
 
 
+_REPO = "SmilingWolf/wd-v1-4-swinv2-tagger-v3"
+_TAGS_FILE = "selected_tags.csv"
+
+
+def _load_tagger(device: torch.device) -> tuple[torch.nn.Module, Any, List[str]]:
+    """Load the WD14 tagger model and tag list from the Hugging Face Hub."""
+
+    log_step("Downloading tagger weights")
+    model, _, preprocess = open_clip.create_model_and_transforms(
+        "swinv2_base_patch4_window8_256",
+        pretrained=f"hf-hub:{_REPO}",
+        device=device,
+    )
+    model.eval()
+
+    tags_path = hf_hub_download(_REPO, _TAGS_FILE)
+    with open(tags_path, newline="") as csvfile:
+        reader = csv.reader(csvfile)
+        tags = [row[0] for row in reader]
+
+    return model, preprocess, tags
+
+
+def _tag_image(
+    model: torch.nn.Module,
+    preprocess: Any,
+    img_path: Path,
+    device: torch.device,
+    tags: List[str],
+    threshold: float = 0.35,
+) -> str:
+    """Return a comma-separated tag string for an image."""
+
+    with Image.open(img_path).convert("RGB") as img:
+        img_tensor = preprocess(img).unsqueeze(0).to(device)
+    with torch.no_grad():
+        logits = model(img_tensor)
+        scores = logits.sigmoid().cpu().numpy()[0]
+
+    selected = [tags[i] for i, s in enumerate(scores) if s > threshold]
+    return ", ".join(selected)
+
+
 def run(cropped_dir: Path, captions_dir: Path) -> None:
-    """Placeholder annotation step that creates dummy captions."""
+    """Run image annotation with automatic tagging and fallback."""
+
     captions_dir.mkdir(parents=True, exist_ok=True)
-    log_step('Annotation started')
-    for img in sorted(cropped_dir.glob('*.png')):
+    log_step("Annotation started")
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    try:
+        model, preprocess, tags = _load_tagger(device)
+    except Exception as exc:  # pragma: no cover - download may fail
+        log_step(f"Tagger unavailable: {exc}; using fallback captions")
+        for img in sorted(cropped_dir.glob("*.png")):
+            caption_file = captions_dir / f"{img.stem}.txt"
+            caption_file.write_text("anime_style")
+        log_step("Annotation completed with fallback")
+        return
+
+    for img in sorted(cropped_dir.glob("*.png")):
+        caption = _tag_image(model, preprocess, img, device, tags)
         caption_file = captions_dir / f"{img.stem}.txt"
-        caption_file.write_text('1girl, solo, anime_style')
-    log_step('Annotation completed')
+        caption_file.write_text(caption)
+
+    log_step("Annotation completed")

--- a/pipeline/steps/classification.py
+++ b/pipeline/steps/classification.py
@@ -1,7 +1,7 @@
 """Character classification using CLIP embeddings and DBSCAN clustering."""
 
 from pathlib import Path
-from typing import List
+from typing import List, Any
 import shutil
 
 import numpy as np
@@ -13,7 +13,7 @@ from sklearn.cluster import DBSCAN
 from ..logging_utils import log_step
 
 
-def _load_model(device: torch.device) -> tuple[torch.nn.Module, open_clip.Preprocess]:
+def _load_model(device: torch.device) -> tuple[torch.nn.Module, Any]:
     """Load an anime-focused CLIP model from the Hugging Face Hub."""
     model, _, preprocess = open_clip.create_model_and_transforms(
         "ViT-B-16",
@@ -25,7 +25,7 @@ def _load_model(device: torch.device) -> tuple[torch.nn.Module, open_clip.Prepro
 
 
 def _embed_images(
-    model: torch.nn.Module, preprocess: open_clip.Preprocess, images: List[Path], device: torch.device
+    model: torch.nn.Module, preprocess: Any, images: List[Path], device: torch.device
 ) -> np.ndarray:
     """Compute normalized CLIP embeddings for all images."""
     features = []


### PR DESCRIPTION
## Summary
- implement WD14-based image tagging with fallback
- update character classification typing
- document the annotation step in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python - <<'EOF'
from pipeline.steps import annotation
print('module', annotation.__name__, 'loaded')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_684d2fb62fe08333bed15c1d488a2f60