### PR TITLE
Improve CLIP weight handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ DataSetKurator turns an anime film into a dataset ready for LoRA training. Every
 1. **Frame Extraction** – `ffmpeg` pulls images from the video
 2. **Deduplication** – perceptual hashing drops duplicates
 3. **Character Classification** – CLIP embeddings clustered via DBSCAN
+   *If the dedicated anime weights cannot be downloaded, the step automatically
+   falls back to the standard OpenAI CLIP weights.*
 4. **Filtering** – remove unwanted shots
 5. **Upscaling & Quality Check** – RealESRGAN or PIL resize with blur/dark checks
 6. **Cropping** – faces cut out using `animeface`

--- a/pipeline/steps/classification.py
+++ b/pipeline/steps/classification.py
@@ -14,12 +14,20 @@ from ..logging_utils import log_step
 
 
 def _load_model(device: torch.device) -> tuple[torch.nn.Module, Any]:
-    """Load an anime-focused CLIP model from the Hugging Face Hub."""
-    model, _, preprocess = open_clip.create_model_and_transforms(
-        "ViT-B-16",
-        pretrained="hf-hub:dudcjs2779/anime-style-tag-clip",
-        device=device,
-    )
+    """Load an anime-focused CLIP model with fallback to the OpenAI weights."""
+    try:
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            "ViT-B-16",
+            pretrained="hf-hub:dudcjs2779/anime-style-tag-clip",
+            device=device,
+        )
+    except Exception as exc:  # pragma: no cover - external download may fail
+        log_step(f"Custom weights unavailable: {exc}; falling back to 'openai'")
+        model, _, preprocess = open_clip.create_model_and_transforms(
+            "ViT-B-16",
+            pretrained="openai",
+            device=device,
+        )
     model.eval()
     return model, preprocess
 


### PR DESCRIPTION
## Summary
- retry classification with OpenAI weights if custom Hugging Face weights fail
- document model fallback in pipeline overview

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d3e424e2c8333b703677ce6080987