### PR TITLE
Add automatic download of WD14 tagger model

### DIFF
--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -21,8 +21,7 @@ def _load_tagger(device: torch.device) -> tuple[torch.nn.Module, Any, List[str]]
 
     log_step("Downloading tagger weights")
     model, _, preprocess = open_clip.create_model_and_transforms(
-        "swinv2_base_patch4_window8_256",
-        pretrained=f"hf-hub:{_REPO}",
+        f"hf-hub:{_REPO}",
         device=device,
     )
     model.eval()


### PR DESCRIPTION
## Summary
- fetch swinv2 tagger via open_clip HF hub URL
- ensure setup checks use the same HF hub mechanism

## Testing
- `bash -n setup.sh`
- `python -m py_compile app.py pipeline/*.py pipeline/steps/*.py`


------
https://chatgpt.com/codex/tasks/task_e_684d40fc84e48333b6fd1de8744d6bf9