### PR TITLE
Fix WD14 tagger download URL

### DIFF
--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -22,6 +22,7 @@ def _load_tagger(device: torch.device) -> tuple[torch.nn.Module, Any, List[str]]
     log_step("Downloading tagger weights")
     model, _, preprocess = open_clip.create_model_and_transforms(
         f"hf-hub:{_REPO}",
+        pretrained=f"hf-hub:{_REPO}/model.safetensors",
         device=device,
     )
     model.eval()


### PR DESCRIPTION
## Summary
- update annotation step to reference the correct `model.safetensors` file when loading the WD14 tagger

## Testing
- `python -m py_compile pipeline/steps/annotation.py`


------
https://chatgpt.com/codex/tasks/task_e_684d4b092e788333ad99b37b4ae78a3a