### PR TITLE
Fix WD14 tagger download

### DIFF
--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -6,8 +6,10 @@ import csv
 
 from PIL import Image
 import torch
-import open_clip
 from huggingface_hub import hf_hub_download
+import numpy as np
+import cv2
+from onnxruntime import InferenceSession
 
 from ..logging_utils import log_step
 
@@ -16,42 +18,70 @@ _REPO = "SmilingWolf/wd-swinv2-tagger-v3"
 _TAGS_FILE = "selected_tags.csv"
 
 
-def _load_tagger(device: torch.device) -> tuple[torch.nn.Module, Any, List[str]]:
-    """Load the WD14 tagger model and tag list from the Hugging Face Hub."""
+def _load_tagger(device: torch.device) -> tuple[InferenceSession, int, List[str]]:
+    """Load the ONNX tagger model and tag list from the Hugging Face Hub."""
 
     log_step("Downloading tagger weights")
-    model, _, preprocess = open_clip.create_model_and_transforms(
-        f"hf-hub:{_REPO}",
-        pretrained=f"hf-hub:{_REPO}/model.safetensors",
-        device=device,
-    )
-    model.eval()
-
+    model_path = hf_hub_download(_REPO, "model.onnx")
     tags_path = hf_hub_download(_REPO, _TAGS_FILE)
+
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if device.type == "cpu":
+        providers = ["CPUExecutionProvider"]
+
+    session = InferenceSession(model_path, providers=providers)
+
     with open(tags_path, newline="") as csvfile:
         reader = csv.reader(csvfile)
-        tags = [row[0] for row in reader]
+        tags = [row[1] for row in reader]
 
-    return model, preprocess, tags
+    input_height = session.get_inputs()[0].shape[2]
+    return session, input_height, tags
+
+
+def _preprocess_image(img: Image.Image, image_size: int) -> np.ndarray:
+    """Prepare an image for the ONNX tagger."""
+
+    img = img.convert("RGBA")
+    new = Image.new("RGBA", img.size, "WHITE")
+    new.paste(img, mask=img)
+    img = new.convert("RGB")
+    img = np.asarray(img)[:, :, ::-1]
+
+    # padding and resizing
+    old_h, old_w = img.shape[:2]
+    desired = max(old_h, old_w, image_size)
+    delta_w = desired - old_w
+    delta_h = desired - old_h
+    top, bottom = delta_h // 2, delta_h - delta_h // 2
+    left, right = delta_w // 2, delta_w - delta_w // 2
+    img = cv2.copyMakeBorder(img, top, bottom, left, right, cv2.BORDER_CONSTANT, value=[255, 255, 255])
+    if img.shape[0] != image_size:
+        interp = cv2.INTER_AREA if img.shape[0] > image_size else cv2.INTER_CUBIC
+        img = cv2.resize(img, (image_size, image_size), interpolation=interp)
+
+    img = img.astype(np.float32)
+    img = np.expand_dims(img, 0)
+    return img
 
 
 def _tag_image(
-    model: torch.nn.Module,
-    preprocess: Any,
+    session: InferenceSession,
+    image_size: int,
     img_path: Path,
-    device: torch.device,
     tags: List[str],
     threshold: float = 0.35,
 ) -> str:
     """Return a comma-separated tag string for an image."""
 
-    with Image.open(img_path).convert("RGB") as img:
-        img_tensor = preprocess(img).unsqueeze(0).to(device)
-    with torch.no_grad():
-        logits = model(img_tensor)
-        scores = logits.sigmoid().cpu().numpy()[0]
+    with Image.open(img_path) as img:
+        img_tensor = _preprocess_image(img, image_size)
 
-    selected = [tags[i] for i, s in enumerate(scores) if s > threshold]
+    input_name = session.get_inputs()[0].name
+    label_name = session.get_outputs()[0].name
+    scores = session.run([label_name], {input_name: img_tensor})[0][0]
+
+    selected = [tags[i] for i, s in enumerate(scores[4:]) if s > threshold]
     return ", ".join(selected)
 
 
@@ -63,7 +93,7 @@ def run(cropped_dir: Path, captions_dir: Path) -> None:
 
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     try:
-        model, preprocess, tags = _load_tagger(device)
+        session, img_size, tags = _load_tagger(device)
     except Exception as exc:  # pragma: no cover - download may fail
         log_step(f"Tagger unavailable: {exc}; using fallback captions")
         for img in sorted(cropped_dir.glob("*.png")):
@@ -73,7 +103,7 @@ def run(cropped_dir: Path, captions_dir: Path) -> None:
         return
 
     for img in sorted(cropped_dir.glob("*.png")):
-        caption = _tag_image(model, preprocess, img, device, tags)
+        caption = _tag_image(session, img_size, img, tags)
         caption_file = captions_dir / f"{img.stem}.txt"
         caption_file.write_text(caption)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ numpy
 huggingface-hub
 realesrgan
 opencv-python
+onnxruntime

--- a/setup.sh
+++ b/setup.sh
@@ -23,11 +23,14 @@ create_venv() {
 check_models() {
   "$APP_DIR/venv/bin/python" <<'PY'
 import sys
-import open_clip
+from huggingface_hub import hf_hub_download
+from onnxruntime import InferenceSession
 
 repo = "SmilingWolf/wd-swinv2-tagger-v3"
 try:
-    open_clip.create_model_and_transforms(f"hf-hub:{repo}")
+    model = hf_hub_download(repo, "model.onnx")
+    InferenceSession(model, providers=["CPUExecutionProvider"])
+    hf_hub_download(repo, "selected_tags.csv")
 except Exception as exc:
     sys.stderr.write(f"Failed to download tagger model: {exc}\n")
     sys.exit(1)


### PR DESCRIPTION
## Summary
- use ONNX Runtime to load the `wd-swinv2-tagger-v3` model
- include `onnxruntime` dependency
- check ONNX model in setup script

## Testing
- `python - <<'PY'
from pipeline.steps.annotation import _load_tagger, _tag_image
import torch
from pathlib import Path
from PIL import Image
import tempfile
session, size, tags = _load_tagger(torch.device('cpu'))
img = Image.new('RGB', (448,448), 'white')
tmp = tempfile.NamedTemporaryFile(suffix='.png', delete=False)
img.save(tmp.name)
caption = _tag_image(session, size, Path(tmp.name), tags)
print('caption', caption[:50])
PY`

------
https://chatgpt.com/codex/tasks/task_e_684d4cea4ed88333808176e93f860e30