### PR TITLE
Fix filtering to include images from all subfolders

### DIFF
--- a/pipeline/steps/filtering.py
+++ b/pipeline/steps/filtering.py
@@ -7,7 +7,9 @@ def run(classified_dir: Path, workdir: Path) -> Path:
     """Placeholder filtering step."""
     workdir.mkdir(parents=True, exist_ok=True)
     log_step('Filtering started')
-    for img in sorted(classified_dir.glob('*.png')):
+    # copy all PNG images from classified_dir and any subfolders
+    for img in sorted(classified_dir.rglob('*.png')):
+        # flatten the directory structure for downstream steps
         shutil.copy(img, workdir / img.name)
     log_step('Filtering completed')
     return workdir


### PR DESCRIPTION
## Summary
- ensure filtering collects images from nested classification directories

## Testing
- `python - <<'EOF'
from pathlib import Path
from pipeline.pipeline_runner import Pipeline
p=Pipeline(Path('input'), Path('output'), Path('work'))
EOF
` *(fails: ModuleNotFoundError after removing venv)*

------
https://chatgpt.com/codex/tasks/task_e_684d51cadae88333802a08ddb9809b0f