### PR TITLE
Isolate pipeline log level

### DIFF
--- a/pipeline/logging_utils.py
+++ b/pipeline/logging_utils.py
@@ -1,19 +1,37 @@
 import logging
 from pathlib import Path
 
-LOG_FILE = Path('logs/process.log')
+LOG_FILE = Path("logs/process.log")
 
 LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
 
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.FileHandler(LOG_FILE, encoding='utf-8'),
-    ]
-)
+# Configure a dedicated log level for the pipeline so that we can ignore
+# noisy messages from other libraries such as Flask/Werkzeug.
+DSK_LEVEL = logging.INFO + 5
+logging.addLevelName(DSK_LEVEL, "DSK")
 
-logger = logging.getLogger('dataset_kurator')
 
-def log_step(step: str):
-    logger.info(step)
+def dsk(self: logging.Logger, message: str, *args, **kwargs) -> None:
+    if self.isEnabledFor(DSK_LEVEL):
+        self._log(DSK_LEVEL, message, args, **kwargs)
+
+
+logging.Logger.dsk = dsk  # type: ignore[attr-defined]
+
+# Silence Flask's request logs that pollute the process log.
+logging.getLogger("werkzeug").setLevel(logging.WARNING)
+
+# Keep the root logger quiet and attach a handler only to our logger.
+logging.basicConfig(level=logging.WARNING)
+
+logger = logging.getLogger("dataset_kurator")
+logger.setLevel(DSK_LEVEL)
+handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+handler.setLevel(DSK_LEVEL)
+handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+logger.addHandler(handler)
+logger.propagate = False
+
+
+def log_step(step: str) -> None:
+    logger.dsk(step)


### PR DESCRIPTION
## Summary
- define custom `DSK` log level and attach handler only to the `dataset_kurator` logger
- silence Flask request logs by raising the werkzeug log level to `WARNING`
- use new level through the `log_step` helper

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684d5f6e45e08333a30053b9d390512c