### PR TITLE
Add trigger word option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ python app.py
 ```
 
 Open [http://localhost:8000](http://localhost:8000) to upload a video and start the pipeline.
+You can optionally set a *trigger word* before starting. This word will be
+prepended as the first tag in every generated caption.

--- a/pipeline/pipeline_runner.py
+++ b/pipeline/pipeline_runner.py
@@ -16,7 +16,16 @@ class Pipeline:
         if self.work_dir.exists():
             shutil.rmtree(self.work_dir)
 
-    def run(self, video_path: Path):
+    def run(self, video_path: Path, *, trigger_word: str = "name"):
+        """Execute the full pipeline on ``video_path``.
+
+        Parameters
+        ----------
+        video_path:
+            Input video file to process.
+        trigger_word:
+            Tag to prepend to every caption. Defaults to ``"name"``.
+        """
         try:
             self.output_dir.mkdir(parents=True, exist_ok=True)
             work_frames = self.work_dir / 'frames'
@@ -47,7 +56,7 @@ class Pipeline:
             images_dir.mkdir(exist_ok=True)
             for img in sorted(cropped.glob('*.png')):
                 shutil.copy(img, images_dir / img.name)
-            annotation.run(cropped, captions_dir)
+            annotation.run(cropped, captions_dir, trigger_word=trigger_word)
             shutil.rmtree(work_crop)
 
             # Zip output


### PR DESCRIPTION
## Summary
- add trigger word option to annotation step
- support passing trigger word through the pipeline
- expose trigger word input in the web interface
- document trigger word in README

## Testing
- `pytest -q`
- `python -m py_compile app.py pipeline/pipeline_runner.py pipeline/steps/annotation.py`


------
https://chatgpt.com/codex/tasks/task_e_684d629f655c83339f555157b219855c