### PR TITLE
Fix YOLO model detection

### DIFF
--- a/pipeline/pipeline_runner.py
+++ b/pipeline/pipeline_runner.py
@@ -28,7 +28,7 @@ class Pipeline:
     def _detect_yolo_model(self) -> Path | None:
         """Return a YOLOv8 weight file from ``models/`` if present."""
         MODELS_DIR.mkdir(exist_ok=True)
-        patterns = ["*yolo*.pt", "*yolo*.pth"]
+        patterns = ["*.pt", "*.pth"]
         for pattern in patterns:
             models = sorted(MODELS_DIR.glob(pattern))
             if models:


### PR DESCRIPTION
## Summary
- relax YOLO model filename pattern

## Testing
- `pip install -q -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_684d73c9c2dc8333ba80022175c3b345