### PR TITLE
Enable hair and eye color classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ DataSetKurator turns an anime film into a dataset ready for LoRA training. Every
 3. **Character Classification** – CLIP embeddings clustered via DBSCAN
    *If the dedicated anime weights cannot be downloaded, the step automatically
    falls back to the standard OpenAI CLIP weights.*
+   Hair and eye color are detected with the WD14 tagger so images are also
+   sorted into folders named `hair_<color>_eyes_<color>`.
 4. **Filtering** – remove unwanted shots
 5. **Upscaling & Quality Check** – RealESRGAN or PIL resize with blur/dark checks
 6. **Cropping** – faces cut out using `animeface` or a YOLOv8 model automatically detected in `models/`

--- a/pipeline/steps/classification.py
+++ b/pipeline/steps/classification.py
@@ -11,6 +11,49 @@ import open_clip
 from sklearn.cluster import DBSCAN
 
 from ..logging_utils import log_step
+from .annotation import _load_tagger, _tag_image
+
+HAIR_COLORS = [
+    "blonde hair",
+    "black hair",
+    "brown hair",
+    "red hair",
+    "blue hair",
+    "green hair",
+    "purple hair",
+    "pink hair",
+    "orange hair",
+    "silver hair",
+    "white hair",
+    "gray hair",
+    "aqua hair",
+]
+
+EYE_COLORS = [
+    "blue eyes",
+    "brown eyes",
+    "red eyes",
+    "green eyes",
+    "purple eyes",
+    "yellow eyes",
+    "pink eyes",
+    "aqua eyes",
+    "orange eyes",
+    "gray eyes",
+]
+
+
+def _detect_color(tag_str: str, colors: List[str], suffix: str) -> str:
+    for c in colors:
+        if c in tag_str:
+            return c.replace(suffix, "").strip()
+    return "unknown"
+
+
+def _detect_attributes(tag_str: str) -> tuple[str, str]:
+    hair = _detect_color(tag_str, HAIR_COLORS, " hair")
+    eyes = _detect_color(tag_str, EYE_COLORS, " eyes")
+    return hair, eyes
 
 
 def _load_model(device: torch.device) -> tuple[torch.nn.Module, Any]:
@@ -66,10 +109,26 @@ def run(frames_dir: Path, workdir: Path, eps: float = 0.3, min_samples: int = 2)
     clusterer = DBSCAN(eps=eps, min_samples=min_samples, metric="cosine")
     labels = clusterer.fit_predict(embeddings)
 
+    # optional hair and eye color detection
+    try:
+        session, img_size, tags = _load_tagger(device)
+    except Exception as exc:  # pragma: no cover - download may fail
+        log_step(f"Tagger unavailable: {exc}; skipping attribute classification")
+        session = None
+
     for img_path, label in zip(images, labels):
         label_dir = workdir / (f"character_{label}" if label >= 0 else "unclassified")
         label_dir.mkdir(exist_ok=True)
         shutil.copy(img_path, label_dir / img_path.name)
+
+        hair = "unknown"
+        eyes = "unknown"
+        if session is not None:
+            tag_str = _tag_image(session, img_size, img_path, tags)
+            hair, eyes = _detect_attributes(tag_str)
+        attr_dir = workdir / f"hair_{hair}_eyes_{eyes}"
+        attr_dir.mkdir(exist_ok=True)
+        shutil.copy(img_path, attr_dir / img_path.name)
 
     log_step("Classification completed")
     return workdir


### PR DESCRIPTION
## Summary
- detect hair and eye color during classification
- group frames into `hair_<color>_eyes_<color>` directories
- document the new behavior in the pipeline overview

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_e_684d75c8921483339963dda2dacf1eb1