### PR TITLE
Reorder pipeline classification step

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,15 +6,12 @@ DataSetKurator turns an anime film into a dataset ready for LoRA training. Every
 
 1. **Frame Extraction** – `ffmpeg` pulls images from the video
 2. **Deduplication** – perceptual hashing drops duplicates
-3. **Character Classification** – CLIP embeddings clustered via DBSCAN
-   *If the dedicated anime weights cannot be downloaded, the step automatically
-   falls back to the standard OpenAI CLIP weights.*
-   Hair and eye color are detected with the WD14 tagger so images are also
-   sorted into folders named `hair_<color>_eyes_<color>`.
-4. **Filtering** – remove unwanted shots
-5. **Upscaling & Quality Check** – RealESRGAN or PIL resize with blur/dark checks
-6. **Cropping** – faces cut out using `animeface` or a YOLOv8 model automatically detected in `models/`
-7. **Annotation** – WD14 tagger generates captions
+3. **Filtering** – remove unwanted shots
+4. **Upscaling & Quality Check** – RealESRGAN or PIL resize with blur/dark checks
+5. **Cropping** – faces cut out using `animeface` or a YOLOv8 model automatically detected in `models/`
+6. **Annotation** – WD14 tagger generates captions
+7. **Character Classification** – images grouped by detected hair and eye color
+   (`<hair>_<eyes>`). Unrecognized images are placed in `unclassified`.
 8. **Packaging** – images and captions are zipped for download
 
 ## Install via setup script

--- a/pipeline/pipeline_runner.py
+++ b/pipeline/pipeline_runner.py
@@ -67,13 +67,9 @@ class Pipeline:
             deduped = deduplication.run(frames, work_dedup)
             shutil.rmtree(work_frames)
 
-            work_class = self.work_dir / 'classification'
-            classified = classification.run(deduped, work_class)
-            shutil.rmtree(work_dedup)
-
             work_filter = self.work_dir / 'filtering'
-            filtered = filtering.run(classified, work_filter)
-            shutil.rmtree(work_class)
+            filtered = filtering.run(deduped, work_filter)
+            shutil.rmtree(work_dedup)
 
             work_upscale = self.work_dir / 'upscaling'
             upscaled = upscaling.run(filtered, work_upscale)
@@ -88,11 +84,13 @@ class Pipeline:
             shutil.rmtree(work_upscale)
 
             captions_dir = self.output_dir / 'captions'
-            images_dir = self.output_dir / 'images'
-            images_dir.mkdir(exist_ok=True)
-            for img in sorted(cropped.glob('*.png')):
-                shutil.copy(img, images_dir / img.name)
             annotation.run(cropped, captions_dir, trigger_word=trigger_word)
+
+            work_class = self.work_dir / 'classification'
+            classified = classification.run(cropped, work_class)
+            images_dir = self.output_dir / 'images'
+            shutil.copytree(classified, images_dir)
+            shutil.rmtree(work_class)
             shutil.rmtree(work_crop)
 
             # Zip output

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@ flask
 pillow
 imagehash
 torch
-open_clip_torch
-scikit-learn
 animeface
 numpy
 huggingface-hub


### PR DESCRIPTION
## Summary
- move character classification to the end of the pipeline
- classify images by detected hair/eye color
- document the new order in the README
- drop unused open_clip and scikit-learn dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684d78a5e13c8333a8a1610a7441fbde