### PR TITLE
Fix commit id display

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,11 +24,19 @@ progress = {"step": 0, "total": 8, "name": "Idle"}
 zip_result: Path | None = None
 
 
+REPO_ROOT = Path(__file__).resolve().parent
+
+
 def get_commit_id() -> str:
-    """Return the short git commit hash for the current repo."""
+    """Return the short git commit hash for the repository.
+
+    Falls back to ``unknown`` if ``git`` is unavailable or the repo is missing.
+    """
     try:
         return (
-            subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'])
+            subprocess.check_output(
+                ["git", "-C", str(REPO_ROOT), "rev-parse", "--short", "HEAD"]
+            )
             .decode()
             .strip()
         )


### PR DESCRIPTION
## Summary
- ensure `git` command runs from repo root when fetching commit id

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684db81c7ef483338475ec8f888f875c