### PR TITLE
Fix RealESRGAN import docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ For the optional upscaling step, download the anime models from
 example ``RealESRGAN_x2plus_anime_6B.pth`` or ``RealESRGAN_x4plus_anime_6B.pth``.
 Place the ``.pth`` file next to ``app.py`` (the working directory) so the
 pipeline can load it. Without the file the step falls back to a basic resize.
+Upscaling also requires the ``realesrgan`` Python package and its dependencies
+(``torch`` and ``torchvision``) to be installed.
 
 If these projects help you, consider starring
 [SoulflareRC/AniRef-yolov8](https://github.com/SoulflareRC/AniRef-yolov8) and

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ flask
 pillow
 imagehash
 torch
+torchvision
 animeface
 numpy
 huggingface-hub


### PR DESCRIPTION
## Summary
- clarify that RealESRGAN requires torch and torchvision
- include torchvision in requirements

## Testing
- `python -m py_compile app.py pipeline/steps/upscaling.py`


------
https://chatgpt.com/codex/tasks/task_e_6853b1ed99c88333803513b6b1b98f8d