### PR TITLE
Fix RealESRGAN import for newer torchvision

### DIFF
--- a/pipeline/steps/upscaling.py
+++ b/pipeline/steps/upscaling.py
@@ -12,6 +12,16 @@ from ..logging_utils import log_step
 
 
 try:  # Optional dependency
+    try:
+        from torchvision.transforms.functional_tensor import rgb_to_grayscale  # type: ignore
+    except Exception:  # pragma: no cover - new torchvision versions
+        from torchvision.transforms.functional import rgb_to_grayscale
+        import types, sys
+
+        shim = types.ModuleType("torchvision.transforms.functional_tensor")
+        shim.rgb_to_grayscale = rgb_to_grayscale
+        sys.modules["torchvision.transforms.functional_tensor"] = shim
+
     from realesrgan import RealESRGAN
 except Exception:  # pragma: no cover - library may not be installed
     RealESRGAN = None  # type: ignore[misc]


### PR DESCRIPTION
## Summary
- fix upscaling to load RealESRGAN with torchvision >=0.17

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_6853ba9a6aac8333ba6eeb129e467a5a