### PR TITLE
Fix RealESRGAN loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,17 @@ installed) or ``animeface``.
 Pretrained weights such as ``AniRef40000-m-epoch75.pt`` can be obtained from the
 [AniRef-yolov8 releases](https://github.com/SoulflareRC/AniRef-yolov8/releases).
 
-For the optional upscaling step, download the anime models from
-[Real-ESRGAN releases](https://github.com/xinntao/Real-ESRGAN/releases/) – for
-example ``RealESRGAN_x2plus_anime_6B.pth`` or ``RealESRGAN_x4plus_anime_6B.pth``.
-Place the ``.pth`` file next to ``app.py`` (the working directory) so the
-pipeline can load it. Without the file the step falls back to a basic resize.
-Upscaling also requires the ``realesrgan`` Python package and its dependencies
-(``torch`` and ``torchvision``) to be installed.
+The optional upscaling step relies on the ``realesrgan`` library (v0.3 or
+newer). When run it automatically downloads
+``RealESRGAN_x4plus_anime_6B.pth`` from the official
+[Real‑ESRGAN releases](https://github.com/xinntao/Real-ESRGAN/releases/) if the
+file does not already exist next to ``app.py``. Keeping the weights in place
+avoids repeated downloads. Upscaling requires ``torch`` and ``torchvision`` to
+be installed.
+
+If RealESRGAN cannot be used you may try alternative models such as
+``realesr-general-x4v3.pth`` or the smaller ``realesr-animevideov3``. External
+tools like Waifu2x or Real‑CUGAN are also viable substitutes.
 
 If these projects help you, consider starring
 [SoulflareRC/AniRef-yolov8](https://github.com/SoulflareRC/AniRef-yolov8) and

--- a/pipeline/steps/upscaling.py
+++ b/pipeline/steps/upscaling.py
@@ -22,7 +22,10 @@ try:  # Optional dependency
         shim.rgb_to_grayscale = rgb_to_grayscale
         sys.modules["torchvision.transforms.functional_tensor"] = shim
 
-    from realesrgan import RealESRGAN
+    try:
+        from realesrgan import RealESRGAN  # old API
+    except Exception:  # pragma: no cover - fallback to new API
+        from realesrgan.utils import RealESRGANer as RealESRGAN
 except Exception:  # pragma: no cover - library may not be installed
     RealESRGAN = None  # type: ignore[misc]
 
@@ -34,9 +37,17 @@ def _load_model(device: torch.device, scale: int) -> Optional[object]:
         log_step("RealESRGAN not available – using PIL resize")
         return None
     try:
-        model = RealESRGAN(device, scale=scale)
-        model.load_weights(f"RealESRGAN_x{scale}plus_anime_6B.pth")
-        model.eval()
+        url = (
+            "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/"
+            "RealESRGAN_x4plus_anime_6B.pth"
+        )
+        # ``RealESRGANer`` automatically downloads weights when given a URL
+        model = RealESRGAN(
+            scale=scale,
+            model_path=url,
+            device=device,
+            half=False,
+        )
         return model
     except Exception as exc:  # pragma: no cover - runtime download may fail
         log_step(f"RealESRGAN load failed: {exc}; falling back to PIL resize")
@@ -79,7 +90,7 @@ def run(
 
             if model is not None:
                 with torch.no_grad():  # pragma: no cover - heavy model inference
-                    upscaled = model.predict(np.array(img))
+                    upscaled, _ = model.enhance(np.array(img))
                 up_img = Image.fromarray(upscaled)
             else:
                 width, height = img.size


### PR DESCRIPTION
## Summary
- load RealESRGANer automatically from official releases
- update upscaling step to call `enhance`
- clarify RealESRGAN setup and alternatives in README
- correct RealESRGAN weight URL

## Testing
- `python -m py_compile pipeline/steps/upscaling.py`
- `pip check`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6853beb6ec8083339acfae518310599f