### PR TITLE
Add per-job log rotation

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,7 +11,7 @@ import shutil
 from threading import Thread
 
 from pipeline.pipeline_runner import Pipeline
-from pipeline.logging_utils import LOG_FILE
+from pipeline.logging_utils import LOG_FILE, rotate_log
 
 INPUT_DIR = Path('input')
 OUTPUT_DIR = Path('output')
@@ -239,9 +239,12 @@ def start():
                 out_dir = OUTPUT_DIR / tw
                 work_dir = WORK_DIR / tw
                 pipeline = Pipeline(INPUT_DIR, out_dir, work_dir)
-                zip_result = pipeline.run(video, trigger_word=tw, progress_cb=update_progress)
-                results.append(Path(zip_result).name)
-                video.unlink()
+                try:
+                    zip_result = pipeline.run(video, trigger_word=tw, progress_cb=update_progress)
+                    results.append(Path(zip_result).name)
+                    video.unlink()
+                finally:
+                    rotate_log(tw)
             update_progress(progress['total'], 'Done')
             status = 'Completed'
         except Exception:

--- a/pipeline/logging_utils.py
+++ b/pipeline/logging_utils.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from datetime import datetime
 
 LOG_FILE = Path("logs/process.log")
 
@@ -35,3 +36,28 @@ logger.propagate = False
 
 def log_step(step: str) -> None:
     logger.dsk(step)
+
+
+def rotate_log(job_name: str) -> None:
+    """Rename the current log file and start a fresh one.
+
+    Parameters
+    ----------
+    job_name:
+        Name of the job that was processed. This will be used in the
+        rotated log file name together with the current date.
+    """
+    global handler
+    logger.handlers[0].flush()
+    logger.removeHandler(handler)
+    handler.close()
+    date_str = datetime.now().strftime("%Y%m%d-%H%M%S")
+    new_path = LOG_FILE.with_name(f"process-{date_str}-{job_name}.log")
+    if LOG_FILE.exists():
+        LOG_FILE.rename(new_path)
+    # Start a fresh log file
+    LOG_FILE.touch()
+    handler = logging.FileHandler(LOG_FILE, encoding="utf-8")
+    handler.setLevel(DSK_LEVEL)
+    handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
+    logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- rotate logs after each job
- make log rotation utility in `logging_utils`
- reset the log in the job loop

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6853ccb7afb88333bfb19618df5be185