### PR TITLE
Fix file uploader

### DIFF
--- a/app.py
+++ b/app.py
@@ -118,12 +118,15 @@ template = """
     dropZone.ondrop = e => {
         e.preventDefault();
         dropZone.classList.remove('hover');
-        if(e.dataTransfer.files.length){
-            fileInput.files = e.dataTransfer.files;
-            uploadFile(e.dataTransfer.files[0]);
+        for (const file of e.dataTransfer.files){
+            uploadFile(file);
         }
     };
-    fileInput.onchange = () => { if(fileInput.files.length) uploadFile(fileInput.files[0]); };
+    fileInput.onchange = () => {
+        for (const file of fileInput.files){
+            uploadFile(file);
+        }
+    };
 
     function uploadFile(file){
         const xhr = new XMLHttpRequest();


### PR DESCRIPTION
## Summary
- fix drag and drop handler to avoid assigning to read-only `files`
- upload multiple files properly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d2621a88833388d33f6be905499a