### PR TITLE
Fix JS newline escape

### DIFF
--- a/app.py
+++ b/app.py
@@ -153,8 +153,8 @@ template = """
       const r = await fetch('/log');
       if(r.ok){
         const text = await r.text();
-        const lines = text.trim().split('\n').reverse();
-        logBox.textContent = lines.join('\n');
+        const lines = text.trim().split('\\n').reverse();
+        logBox.textContent = lines.join('\\n');
         logBox.scrollTop = 0;
       }
     }


### PR DESCRIPTION
## Summary
- ensure `\n` in fetchLog JS stays literal by escaping backslashes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6853e857f594833390b6a9b76d80546e