### PR TITLE
Fix RealESRGAN weight selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ Pretrained weights such as ``AniRef40000-m-epoch75.pt`` can be obtained from the
 
 The optional upscaling step relies on the ``realesrgan`` library (v0.3 or
 newer). When run it automatically downloads
-
-``RealESRGAN_x4plus_anime_6B.pth`` from the official
-[Real‑ESRGAN releases](https://github.com/xinntao/Real-ESRGAN/releases/) if the
-file does not already exist next to ``app.py``. Keeping the weights in place
-avoids repeated downloads. Upscaling requires ``torch`` and ``torchvision`` to
-be installed.
+``realesr-animevideov3.pth`` if the modern ``RealESRGANer`` API is available.
+Older versions fall back to ``RealESRGAN_x4plus_anime_6B.pth``. Both files are
+fetched from the official
+[Real‑ESRGAN releases](https://github.com/xinntao/Real-ESRGAN/releases/). Keep
+the weights next to ``app.py`` to avoid repeated downloads. Upscaling requires
+``torch`` and ``torchvision`` to be installed.
 
 If RealESRGAN cannot be used you may try alternative models such as
 ``realesr-general-x4v3.pth`` or the smaller ``realesr-animevideov3``. External

--- a/pipeline/steps/upscaling.py
+++ b/pipeline/steps/upscaling.py
@@ -37,13 +37,13 @@ def _load_model(device: torch.device, scale: int) -> Optional[object]:
         log_step("RealESRGAN not available – using PIL resize")
         return None
     try:
-        url = (
-            "https://github.com/xinntao/Real-ESRGAN/releases/download/v0.2.2.4/"
-            "RealESRGAN_x4plus_anime_6B.pth"
-        )
         if RealESRGAN.__name__ == "RealESRGANer":  # modernes API
             from realesrgan.archs.srvgg_arch import SRVGGNetCompact
 
+            url = (
+                "https://github.com/xinntao/Real-ESRGAN/releases/download/"
+                "v0.2.5.0/realesr-animevideov3.pth"
+            )
             arch = SRVGGNetCompact(
                 num_in_ch=3,
                 num_out_ch=3,
@@ -61,6 +61,10 @@ def _load_model(device: torch.device, scale: int) -> Optional[object]:
                 half=False,
             )
         else:  # ältere API
+            url = (
+                "https://github.com/xinntao/Real-ESRGAN/releases/download/"
+                "v0.2.2.4/RealESRGAN_x4plus_anime_6B.pth"
+            )
             model = RealESRGAN(device, scale=scale)
             model.load_weights(url)
         return model


### PR DESCRIPTION
## Summary
- use animevideov3 weights when the modern RealESRGANer API is available
- clarify weight download logic in README

## Testing
- `python -m py_compile app.py pipeline/steps/upscaling.py`

------
https://chatgpt.com/codex/tasks/task_e_6853f1b859d883339bfe124151325bea