### PR TITLE
Fix RealESRGAN default scale

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Older versions fall back to ``RealESRGAN_x4plus_anime_6B.pth``. Both files are
 fetched from the official
 [Real‑ESRGAN releases](https://github.com/xinntao/Real-ESRGAN/releases/). Keep
 the weights next to ``app.py`` to avoid repeated downloads. Upscaling requires
-``torch`` and ``torchvision`` to be installed.
+``torch`` and ``torchvision`` to be installed. Upscaling defaults to a 4x scale
+factor to match the ``realesr-animevideov3`` model.
 
 If RealESRGAN cannot be used you may try alternative models such as
 ``realesr-general-x4v3.pth`` or the smaller ``realesr-animevideov3``. External

--- a/pipeline/steps/upscaling.py
+++ b/pipeline/steps/upscaling.py
@@ -90,7 +90,7 @@ def run(
     filtered_dir: Path,
     workdir: Path,
     *,
-    scale: int = 2,
+    scale: int = 4,
     blur_threshold: float = 100.0,
     dark_threshold: float = 40.0,
 ) -> Path:


### PR DESCRIPTION
## Summary
- default the upscaling step to 4x
- explain the 4x default in README

## Testing
- `pip check`

------
https://chatgpt.com/codex/tasks/task_e_6853f5b1cf84833394548230d29a445b