### PR TITLE
Fix WD14 tagger annotation crash

### DIFF
--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -33,6 +33,7 @@ def _load_tagger(device: torch.device) -> tuple[InferenceSession, int, List[str]
 
     with open(tags_path, newline="") as csvfile:
         reader = csv.reader(csvfile)
+        next(reader, None)  # skip header row
         tags = [row[1] for row in reader]
 
     input_height = session.get_inputs()[0].shape[2]


### PR DESCRIPTION
## Summary
- skip header row in annotation tag list to match model output

## Testing
- `python -m py_compile pipeline/steps/annotation.py`


------
https://chatgpt.com/codex/tasks/task_e_68546402554483339518da754efab032