### PR TITLE
Fix tag index issue in annotation step

### DIFF
--- a/pipeline/steps/annotation.py
+++ b/pipeline/steps/annotation.py
@@ -106,8 +106,9 @@ def _tag_image(
     label_name = session.get_outputs()[0].name
     scores = session.run([label_name], {input_name: img_tensor})[0][0]
 
+    max_idx = min(len(tags), len(scores) - 4)
     tag_scores = [
-        (tags[i], float(scores[i + 4])) for i in range(len(tags))
+        (tags[i], float(scores[i + 4])) for i in range(max_idx)
     ]
     tag_scores.sort(key=lambda x: x[1], reverse=True)
 


### PR DESCRIPTION
## Summary
- handle mismatched tag counts in annotation step

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6854f44ec5088333943d8acdfb3d0d17